### PR TITLE
centos-cert: remove unused variables

### DIFF
--- a/SOURCES/centos-cert
+++ b/SOURCES/centos-cert
@@ -14,15 +14,9 @@ from centos import CentOSUserCert
 from centos import defaults
 
 
-def download_cert(username, password, topurl=None, servercacert=None, uploadcacert=None):
+def download_cert(username, password, topurl=None):
     if not topurl:
         topurl = defaults.FAS_TOPURL
-
-    if not servercacert:
-        servercacert = defaults.SERVER_CA_CERT_FILE
-
-    if not uploadcacert:
-        uploadcacert = defaults.UPLOAD_CA_CERT_FILE
 
     splittopurl = urlparse.urlsplit(topurl)
 


### PR DESCRIPTION
The servercacert and uploadcacert variables were unused. Delete them to make this more readable.