### PR TITLE
Python 3 / Fedora 31 compatibility

### DIFF
--- a/SOURCES/centos-cert
+++ b/SOURCES/centos-cert
@@ -1,17 +1,22 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+from __future__ import print_function
 
 import os
 import pwd
 import sys
 import optparse
-import urlparse
 import requests
 
 from getpass import getpass
 
 from centos import CentOSUserCert
 from centos import defaults
+
+try:
+    import urlparse
+except ImportError:
+    import urllib.parse as urlparse
 
 
 def download_cert(username, password, topurl=None):
@@ -46,7 +51,7 @@ def download_cert(username, password, topurl=None):
         except requests.exceptions.HTTPError as e:
             print("""Could not generate certificate!
 Response Code: {0}
-Message: {1}""".format(e.response.status_code, e.response.reason)).strip()
+Message: {1}""".format(e.response.status_code, e.response.reason).strip())
             sys.exit(1)
 
         response = r.text
@@ -59,7 +64,7 @@ Message: {1}""".format(e.response.status_code, e.response.reason)).strip()
         except requests.exceptions.HTTPError as e:
             print("""Could not download CA Certificate!
 Response Code: {0}
-Message: {1}""".format(e.response.status_code, e.response.reason)).strip()
+Message: {1}""".format(e.response.status_code, e.response.reason).strip())
             sys.exit(1)
 
         response = r.text
@@ -88,26 +93,26 @@ def main(opts):
         try:
             cert = CentOSUserCert(certfile)
             username = cert.CN
-        except IOError, e:
+        except IOError as e:
             if opts.verifycert:
-                print "{0}: {1}".format(os.path.expanduser(certfile), e.strerror)
+                print("{0}: {1}".format(os.path.expanduser(certfile), e.strerror))
                 exit(1)
             username = pwd.getpwuid(os.geteuid())[0]
 
     if opts.verifycert:
         if not cert.valid:
-            print "Your certificate is not valid"
+            print("Your certificate is not valid")
             sys.exit(1)
         else:
-            print "Your certificate is valid"
+            print("Your certificate is valid")
             sys.exit(0)
 
     if opts.newcert:
         password = getpass('ACO Password: ')
         download_cert(username, password)
 
-if __name__ == '__main__':
 
+if __name__ == '__main__':
     parser = optparse.OptionParser(usage="%prog [OPTIONS] ")
     parser.add_option('-u', '--username', action='store', dest='username',
                       default=False, help="ACO Username.")
@@ -120,7 +125,7 @@ if __name__ == '__main__':
     opts, args = parser.parse_args()
 
     if not opts.newcert and not opts.verifycert:
-        print "Must specify one of arguments: -v or -n"
+        print("Must specify one of arguments: -v or -n")
         parser.print_help()
         sys.exit(1)
 

--- a/SPECS/centos-packager.spec
+++ b/SPECS/centos-packager.spec
@@ -1,6 +1,17 @@
+%if 0%{?fedora} >= 28 || 0%{?rhel} >= 8
+# Use Python 3
+%global     python_major_version 3
+%global     python_dist()   python3dist(%1)
+%else
+# Use Python 2
+%global     python_major_version 2
+%global     python_dist()   python2-%1
+%endif
+
+
 Name:           centos-packager
 Version:        0.5.5
-Release:        1%{?dist}
+Release:        2%{?dist}
 Summary:        Tools and files necessary for building CentOS packages
 Group:          Applications/Productivity
 
@@ -14,7 +25,7 @@ Requires:       koji
 Requires:       rpm-build rpmdevtools rpmlint
 Requires:       mock curl openssh-clients
 Requires:       redhat-rpm-config
-Requires:       python-centos
+Requires:       %{python_dist centos}
 
 BuildArch:      noarch
 
@@ -34,6 +45,9 @@ cp %{SOURCE1} .
 
 %{__mkdir_p} %{buildroot}/%{_bindir}
 ln -sf %{_bindir}/koji %{buildroot}%{_bindir}/cbs
+
+# Fix shebang to require explicit python version
+sed -i.backup -E '1s|#!/usr/bin/python\>|\0%{python_major_version}|' %{SOURCE2}
 %{__install} -m 0755 %{SOURCE2} %{buildroot}%{_bindir}/centos-cert
 
 %files
@@ -44,6 +58,9 @@ ln -sf %{_bindir}/koji %{buildroot}%{_bindir}/cbs
 %{_bindir}/centos-cert
 
 %changelog
+* Wed Nov 27 2019 Jan Staněk <jstanek@redhat.com> - 0.5.5-2
+- Use Python3 on F28+ and EL 8+
+
 * Mon Nov 28 2016 brian@bstinson.com 0.5.5-1
 - Update more references to ACO
 - Make sure Exception messages don't print credentials to the screen
@@ -69,7 +86,7 @@ ln -sf %{_bindir}/koji %{buildroot}%{_bindir}/cbs
 
 * Sun Jul 26 2015 brian@bstinson.com 0.2.0-1
 - Added the centos_cert utility
-- Remove the dep on centpkg 
+- Remove the dep on centpkg
 - Add a dep for python-centos
 
 * Sun Dec 14 2014 Brian Stinson <bstinson@ksu.edu> - 0.1.0-1


### PR DESCRIPTION
This is an attempt to make the `centos-packager` instalable on Fedora 31.

- `centos-cert` was adjusted to be Python 3 compatible
- Spec file was adjusted to pull Python 2 or Python 3 version of the `python-centos` package depending on target platform. The current instructions use [my modified version of `python-centos`](https://github.com/bstinsonmhk/python-centos/pull/2).

Test builds are available in the [jstanek/centos-packager](https://copr.fedorainfracloud.org/coprs/jstanek/centos-packager/) COPR; I was able to successfully regenerate my CentOS certificate on F31 using them.